### PR TITLE
文字起こし後のWiki投稿機能

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+BASE_URL=<your_api_url>
+ZEMI_ASR_COLLECTION_ID=<your_collection_id>
+OUTLINE_API_TOKEN=<your_api_token>

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # general development files
+.env/
 .venv/
 **/__pycache__/
 **/.DS_Store

--- a/src/shinki_zemi_asr/asr.py
+++ b/src/shinki_zemi_asr/asr.py
@@ -21,8 +21,7 @@ class ASRModel():
                              feature_extractor=self.processor.feature_extractor,
                              torch_dtype=self.torch_dtype,
                              device=self.device,
-                             return_timestamps=True,
-                             generate_kwargs={"language": "ja"})
+                             return_timestamps=True)
 
     def transcribe(self, audio_path : str):
         result = self.pipe(audio_path)

--- a/src/shinki_zemi_asr/services/transcriber.py
+++ b/src/shinki_zemi_asr/services/transcriber.py
@@ -1,5 +1,6 @@
 from src.shinki_zemi_asr.asr import ASRModel
 from src.shinki_zemi_asr.utils.file_operations import convert_tuple_to_list, save_transcription
+from src.shinki_zemi_asr.utils.output_to_wiki import output_to_wiki
 from src.shinki_zemi_asr.database.csv_operations import update_processing_status
 from src.shinki_zemi_asr.config import AppState
 
@@ -17,6 +18,9 @@ def process_audio_file(audio_file_path: str):
         
         # Convert transcript data for JSON serialization
         converted_transcript = convert_tuple_to_list(transcript)
+
+        # Output to wiki
+        output_to_wiki(text = converted_transcript)
         
         # Save transcription to file
         save_transcription(audio_file_path, converted_transcript)

--- a/src/shinki_zemi_asr/services/transcriber.py
+++ b/src/shinki_zemi_asr/services/transcriber.py
@@ -18,13 +18,13 @@ def process_audio_file(audio_file_path: str):
         
         # Convert transcript data for JSON serialization
         converted_transcript = convert_tuple_to_list(transcript)
-
-        # Output to wiki
-        output_to_wiki(text = converted_transcript)
         
         # Save transcription to file
-        save_transcription(audio_file_path, converted_transcript)
+        transcript_info = save_transcription(audio_file_path, converted_transcript)
         
+        # Output to wiki
+        output_to_wiki(converted_transcript, transcript_info)
+
         # Update processing status in the database
         update_processing_status(audio_file_path, True)
         

--- a/src/shinki_zemi_asr/services/transcriber.py
+++ b/src/shinki_zemi_asr/services/transcriber.py
@@ -20,10 +20,10 @@ def process_audio_file(audio_file_path: str):
         converted_transcript = convert_tuple_to_list(transcript)
         
         # Save transcription to file
-        transcript_info = save_transcription(audio_file_path, converted_transcript)
+        filepath = save_transcription(audio_file_path, converted_transcript)
         
         # Output to wiki
-        output_to_wiki(converted_transcript, transcript_info)
+        output_to_wiki(converted_transcript, filepath)
 
         # Update processing status in the database
         update_processing_status(audio_file_path, True)

--- a/src/shinki_zemi_asr/services/transcriber.py
+++ b/src/shinki_zemi_asr/services/transcriber.py
@@ -23,7 +23,7 @@ def process_audio_file(audio_file_path: str):
         filepath = save_transcription(audio_file_path, converted_transcript)
         
         # Output to wiki
-        output_to_wiki(converted_transcript, filepath)
+        output_to_wiki(str(converted_transcript), str(filepath))
 
         # Update processing status in the database
         update_processing_status(audio_file_path, True)

--- a/src/shinki_zemi_asr/utils/output_to_wiki.py
+++ b/src/shinki_zemi_asr/utils/output_to_wiki.py
@@ -13,11 +13,12 @@ BASE_URL = os.getenv("BASE_URL")
 COLLECTION_ID = os.getenv("ZEMI_ASR_COLLECTION_ID")
 API_TOKEN     = os.getenv("OUTLINE_API_TOKEN")
 
-def get_title(filename: str) -> str:
+def get_title(filepath: str) -> str:
     """
-    :param filename: ファイル名 (例: "kazuma_20250427_1200_1300.json")
+    :param filepath: ファイル名 (例: "kazuma_20250427_1200_1300.json")
     :return: タイトル (例: "20250427_kazuma")
     """
+    filename = os.path.basename(filepath)
     pattern = re.compile(
         r'^(?P<username>[^_]+)_'      # ユーザ名 (アンダースコア以外)
         r'(?P<date>\d{8})_'           # 日付 (YYYYMMDD)
@@ -32,7 +33,7 @@ def get_title(filename: str) -> str:
     username = m.group('username')
     return f"{date}_{username}"
 
-def output_to_wiki(text: str, filename: str) -> dict:
+def output_to_wiki(text: str, filepath: str) -> dict:
     """
     Outline API を呼び出してドキュメントを作成します。
 
@@ -43,7 +44,7 @@ def output_to_wiki(text: str, filename: str) -> dict:
     """
     url = f"{BASE_URL}/documents.create"
     payload = {
-        "title":        get_title(filename),  # タイトル
+        "title":        get_title(filepath),  # タイトル
         "text":         text,
         "collectionId": COLLECTION_ID,
         "publish":      True

--- a/src/shinki_zemi_asr/utils/output_to_wiki.py
+++ b/src/shinki_zemi_asr/utils/output_to_wiki.py
@@ -1,0 +1,99 @@
+# src/shinki_zemi_asr/utils/output_to_wiki.py
+
+import os
+import requests
+from dotenv import load_dotenv
+
+# .env から環境変数をロード
+load_dotenv()
+
+# 環境変数の取得
+BASE_URL = os.getenv("BASE_URL")
+COLLECTION_ID = os.getenv("ZEMI_ASR_COLLECTION_ID")
+API_TOKEN     = os.getenv("OUTLINE_API_TOKEN")
+
+import re
+from pathlib import Path
+from datetime import datetime
+
+def get_latest_transcription_info():
+    """
+    Transcription フォルダ内のファイル名規則:
+      {username}_{YYYYMMDD}_{HHMM}_{HHMM}.json
+    にマッチするファイルを検索し、
+    日付 + 開始時刻 が最も新しいファイルの
+    (ユーザ名, 日付 (YYYYMMDD), ファイル名) を返す。
+    """
+    # Transcription ディレクトリへのパスを取得
+    transcription_dir = Path(__file__).resolve().parent.parent / 'Transcription'
+
+    # ファイル名パターン
+    pattern = re.compile(
+        r'^(?P<username>[^_]+)_'      # ユーザ名 (アンダースコア以外)
+        r'(?P<date>\d{8})_'           # 日付 (YYYYMMDD)
+        r'(?P<start>\d{4})_'          # 開始時刻 (HHMM)
+        r'(?P<end>\d{4})\.json$'      # 終了時刻 (HHMM) + .json
+    )
+
+    latest_dt = None
+    latest_info = None
+
+    for file in transcription_dir.iterdir():
+        if file.suffix.lower() != '.json':
+            continue
+        m = pattern.match(file.name)
+        if not m:
+            continue
+
+        # 比較用の datetime を作成 (日付＋開始時刻)
+        dt = datetime.strptime(m.group('date') + m.group('start'), '%Y%m%d%H%M')
+
+        if latest_dt is None or dt > latest_dt:
+            latest_dt = dt
+            latest_info = {
+                'username': m.group('username'),
+                'date': m.group('date'),
+                'filename': file.name
+            }
+
+    if latest_info is None:
+        raise FileNotFoundError(f"No matching JSON files in {transcription_dir}")
+
+    return latest_info
+
+def get_title() -> str:
+    """
+    :param filename: ファイル名 (例: "kazuma_20250427_1200_1300.json")
+    :return: タイトル (例: "20250427_kazuma")
+    """
+    # src/shinki_zemi_asr/Transcriptionからfilename,dateを取得する
+    info = get_latest_transcription_info() 
+    return f"{info['date']}_{info['username']}"
+
+
+def output_to_wiki(text: str) -> dict:
+    """
+    Outline API を呼び出してドキュメントを作成します。
+
+    :param title: ドキュメントのタイトル
+    :param text: 本文テキスト
+    :param publish: 公開フラグ (True/False)
+    :return: API のレスポンス JSON を辞書で返す
+    """
+    url = f"{BASE_URL}/documents.create"
+    payload = {
+        "title":        get_title(),
+        "text":         text,
+        "collectionId": COLLECTION_ID,
+        "publish":      True
+    }
+    headers = {
+        "Content-Type":  "application/json",
+        "Authorization": f"Bearer {API_TOKEN}"
+    }
+
+    resp = requests.post(url, json=payload, headers=headers)
+    # ステータスコード 200 異常時は例外を投げる
+    resp.raise_for_status()
+    return resp.json()
+

--- a/src/shinki_zemi_asr/utils/output_to_wiki.py
+++ b/src/shinki_zemi_asr/utils/output_to_wiki.py
@@ -1,6 +1,7 @@
 # src/shinki_zemi_asr/utils/output_to_wiki.py
 
 import os
+import re
 import requests
 from dotenv import load_dotenv
 
@@ -12,66 +13,26 @@ BASE_URL = os.getenv("BASE_URL")
 COLLECTION_ID = os.getenv("ZEMI_ASR_COLLECTION_ID")
 API_TOKEN     = os.getenv("OUTLINE_API_TOKEN")
 
-import re
-from pathlib import Path
-from datetime import datetime
-
-def get_latest_transcription_info():
+def get_title(filename: str) -> str:
     """
-    Transcription フォルダ内のファイル名規則:
-      {username}_{YYYYMMDD}_{HHMM}_{HHMM}.json
-    にマッチするファイルを検索し、
-    日付 + 開始時刻 が最も新しいファイルの
-    (ユーザ名, 日付 (YYYYMMDD), ファイル名) を返す。
+    :param filename: ファイル名 (例: "kazuma_20250427_1200_1300.json")
+    :return: タイトル (例: "20250427_kazuma")
     """
-    # Transcription ディレクトリへのパスを取得
-    transcription_dir = Path(__file__).resolve().parent.parent / 'Transcription'
-
-    # ファイル名パターン
     pattern = re.compile(
         r'^(?P<username>[^_]+)_'      # ユーザ名 (アンダースコア以外)
         r'(?P<date>\d{8})_'           # 日付 (YYYYMMDD)
         r'(?P<start>\d{4})_'          # 開始時刻 (HHMM)
         r'(?P<end>\d{4})\.json$'      # 終了時刻 (HHMM) + .json
     )
+    m = pattern.match(filename)
+    if not m:
+        raise ValueError(f"無効なファイル名形式: {filename}")
 
-    latest_dt = None
-    latest_info = None
+    date = m.group('date')
+    username = m.group('username')
+    return f"{date}_{username}"
 
-    for file in transcription_dir.iterdir():
-        if file.suffix.lower() != '.json':
-            continue
-        m = pattern.match(file.name)
-        if not m:
-            continue
-
-        # 比較用の datetime を作成 (日付＋開始時刻)
-        dt = datetime.strptime(m.group('date') + m.group('start'), '%Y%m%d%H%M')
-
-        if latest_dt is None or dt > latest_dt:
-            latest_dt = dt
-            latest_info = {
-                'username': m.group('username'),
-                'date': m.group('date'),
-                'filename': file.name
-            }
-
-    if latest_info is None:
-        raise FileNotFoundError(f"No matching JSON files in {transcription_dir}")
-
-    return latest_info
-
-def get_title() -> str:
-    """
-    :param filename: ファイル名 (例: "kazuma_20250427_1200_1300.json")
-    :return: タイトル (例: "20250427_kazuma")
-    """
-    # src/shinki_zemi_asr/Transcriptionからfilename,dateを取得する
-    info = get_latest_transcription_info() 
-    return f"{info['date']}_{info['username']}"
-
-
-def output_to_wiki(text: str) -> dict:
+def output_to_wiki(text: str, filename: str) -> dict:
     """
     Outline API を呼び出してドキュメントを作成します。
 
@@ -82,7 +43,7 @@ def output_to_wiki(text: str) -> dict:
     """
     url = f"{BASE_URL}/documents.create"
     payload = {
-        "title":        get_title(),
+        "title":        get_title(filename),  # タイトル
         "text":         text,
         "collectionId": COLLECTION_ID,
         "publish":      True
@@ -96,4 +57,3 @@ def output_to_wiki(text: str) -> dict:
     # ステータスコード 200 異常時は例外を投げる
     resp.raise_for_status()
     return resp.json()
-


### PR DESCRIPTION
# 📄 #6  文字起こし後のWiki投稿機能

---

## 📝 概要
- 文字起こし完了後に自動でWikiにドキュメントを投稿する処理を実装

---

## 🔍 変更内容

1. **Wikiタイトルの自動生成**  
   - `src/shinki_zemi_asr/Transcription` 配下の JSON ファイル名から、  
     日付（YYYYMMDD）＋開始時刻（HHMM）で「最新ファイル」を判別  
   - 最新ファイル名からユーザー名と日付を抽出し、  
     `YYYYMMDD_username` の形式でタイトルを生成  
   - **例**  
     ```text
     kazuma_20250427_1200_1300.json  →  20250427_kazuma
     ```

2. **API 接続情報の外部化**  
   - IP アドレスや Outline API トークン等を環境変数（`.env`）で管理

3. **今後の検討事項**  
   - 「掲載ボタン」機能を追加した際の後続処理については、要件確定後に実装予定

---

## 🚀 動作確認手順
1. `.env` に以下を設定  
   ```env
   BASE_URL=<your_api_url>
   ZEMI_ASR_COLLECTION_ID=<your_collection_id>
   OUTLINE_API_TOKEN=<your_api_token>
